### PR TITLE
Add CMAKE_ARGS to log

### DIFF
--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -781,6 +781,7 @@ buildlog_start() {
 	    MAINTAINER
 	    CONFIGURE_ARGS
 	    CONFIGURE_ENV
+	    CMAKE_ARGS
 	    MAKE_ENV
 	    PLIST_SUB
 	    SUB_LIST


### PR DESCRIPTION
Poudriere currently logs the args and environment for configure but not for cmake.